### PR TITLE
round canary times to the second

### DIFF
--- a/cmd/client/op_verify.go
+++ b/cmd/client/op_verify.go
@@ -52,6 +52,6 @@ func operationVerify(flags Flags) {
 		exitError(EXIT_INVALID_CANARY, "Failed to validate canary fields: %s", err.Error())
 	}
 	fmt.Println("Author:", canary.Author)
-	fmt.Println("Expires:", canary.Expiry.Time().Format(fugl.CanaryTimeFormat))
+	fmt.Println("Expires:", canary.Expiry.String())
 	fmt.Println("Description:\n" + description)
 }

--- a/types.go
+++ b/types.go
@@ -3,6 +3,7 @@ package fugl
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 )
 
@@ -18,11 +19,21 @@ type Canary struct {
 	Final    bool       `json:"final"`    // Is this canary final?
 }
 
+func (c Canary) Equal(other Canary) bool {
+	return (c.Version == other.Version) &&
+		(c.Author == other.Author) &&
+		c.Creation.Time().Equal(other.Creation.Time()) &&
+		c.Expiry.Time().Equal(other.Expiry.Time()) &&
+		reflect.DeepEqual(c.Promises, other.Promises) &&
+		(c.Nonce == other.Nonce) &&
+		(c.Final == other.Final)
+}
+
 /* specifies the time format used in the canaries
  */
 
 func (t CanaryTime) MarshalJSON() ([]byte, error) {
-	stamp := fmt.Sprintf("\"%s\"", time.Time(t).Format(CanaryTimeFormat))
+	stamp := fmt.Sprintf("\"%s\"", t.String())
 	return []byte(stamp), nil
 }
 
@@ -43,5 +54,9 @@ func (t *CanaryTime) UnmarshalJSON(val []byte) error {
 }
 
 func (t CanaryTime) Time() time.Time {
-	return time.Time(t)
+	return time.Time(t).Round(1 * time.Second)
+}
+
+func (t CanaryTime) String() string {
+	return t.Time().Format(CanaryTimeFormat)
 }

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,38 @@
+package fugl
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestCanarySerializeCycle(t *testing.T) {
+	canary := Canary{
+		Version: 1,
+		Author: "John Doe",
+		Creation: CanaryTime(time.Now()),
+		Expiry: CanaryTime(time.Now()),
+		Promises: []string{"example"},
+		Nonce: "nonce",
+		Final: false,
+	}
+
+	bs, err := json.Marshal(canary)
+	if err != nil {
+		t.Fatalf("error encoding Canary to json, err=%v", err)
+	}
+
+	var out Canary
+	err = json.Unmarshal(bs, &out)
+	if err != nil {
+		t.Fatalf("error decoding Canary from json, err=%v", err)
+	}
+
+	if !canary.Equal(out) {
+		fmt.Printf("canary=%v\n", canary)
+		fmt.Printf("out   =%v\n", out)
+
+		t.Fatal("serialization cycle mismatch")
+	}
+}


### PR DESCRIPTION
This also adds a cycle serialization test which was failing without
this rounding taken into account. `time.Now()` creates a more specific
time than what the json decoding was expecting.